### PR TITLE
Fix "unused function" warning seen with gcc.

### DIFF
--- a/PackedArray.c
+++ b/PackedArray.c
@@ -579,7 +579,7 @@ uint32_t PackedArray_bufferSize(const PackedArray* a)
   return (uint32_t)(((uint64_t)a->bitsPerItem * (uint64_t)a->count + 31) / 32);
 }
 
-#if !(defined(_MSC_VER) && _MSC_VER >= 1400) || !defined(__GNUC__)
+#if !(defined(_MSC_VER) && _MSC_VER >= 1400) && !defined(__GNUC__)
 // log base 2 of an integer, aka the position of the highest bit set
 static uint32_t __PackedArray_log2(uint32_t v)
 {

--- a/PackedArraySIMD.c
+++ b/PackedArraySIMD.c
@@ -808,7 +808,7 @@ uint32_t PackedArray_bufferSize(const PackedArray* a)
   return (uint32_t)bufferSize;
 }
 
-#if !(defined(_MSC_VER) && _MSC_VER >= 1400) || !defined(__GNUC__)
+#if !(defined(_MSC_VER) && _MSC_VER >= 1400) && !defined(__GNUC__)
 // log base 2 of an integer, aka the position of the highest bit set
 static uint32_t __PackedArray_log2(uint32_t v)
 {


### PR DESCRIPTION
`highestBitSet` does not use `log2` when using a newish Microsoft compiler or gcc.  Therefore `log2` needs to be defined only when neither using a newish Microsoft compiler, nor gcc.  De Morgan's laws in action!
