### PR TITLE
0 Initalized packed array buffer

### DIFF
--- a/PackedArray.c
+++ b/PackedArray.c
@@ -1,6 +1,8 @@
 // see README.md for usage instructions.
 // (‑●‑●)> released under the WTFPL v2 license, by Gregory Pakosz (@gpakosz)
 
+#include <string.h>
+
 #ifndef PACKEDARRAY_SELF
 #define PACKEDARRAY_SELF "PackedArray.c"
 #endif
@@ -403,6 +405,8 @@ PackedArray* PackedArray_create(uint32_t bitsPerItem, uint32_t count)
     a->bitsPerItem = bitsPerItem;
     a->count = count;
   }
+
+  memset(a->buffer, 0, bufferSize);
 
   return a;
 }


### PR DESCRIPTION
I have 0 initialized the PackedArray buffer. I was valrgrind'ing around in my application and was getting `Conditional jump or move depends on uninitialised value(s)`  when using a 1- bit packed array buffer and was getting incorrect results. This fix resolves the issue. I reran the tests and everything is passing. This is a fix for #6 

Bug can be reproduced in this [commit](https://github.com/guinn8/aliquot/commit/16229a74ea8a011c384c8278e160226180573360) with this  input `aliquot/_pom_yang_rewrite/ make && valgrind ./main --bound=$((10**6)) --seg_len=$((5 * $((10**3)))) --writebuf_len=1000000 --preimage_count_bits=1 --num_threads=12`